### PR TITLE
Fixed menu item assignment in DBDetails.xaml.cs

### DIFF
--- a/KeePass/DBDetails.xaml.cs
+++ b/KeePass/DBDetails.xaml.cs
@@ -49,9 +49,9 @@ namespace KeePass
             btnClose.Text = Strings.EntryDetails_ResetEntry;
             btnDelete.Text = Strings.GroupDetails_Delete;
 
-            mnuDlKeyFile = ApplicationBar.MenuItems[0] as ApplicationBarMenuItem;
-            mnuDelKeyFile = ApplicationBar.MenuItems[1] as ApplicationBarMenuItem;
-            mnuClearPW = ApplicationBar.MenuItems[2] as ApplicationBarMenuItem;
+            mnuClearPW = ApplicationBar.MenuItems[0] as ApplicationBarMenuItem;
+            mnuDlKeyFile = ApplicationBar.MenuItems[1] as ApplicationBarMenuItem;
+            mnuDelKeyFile = ApplicationBar.MenuItems[2] as ApplicationBarMenuItem;
             mnuDlKeyFile.Text = Strings.MainPage_DownloadKeyfile;
             mnuDelKeyFile.Text = Strings.MainPage_ClearKeyfile;
             mnuClearPW.Text = Strings.MainPage_ClearPassword;


### PR DESCRIPTION
Hi all,

I changed the assignment of menu item objects in DBDetails.xaml.cs, because otherwise it was not possible to add a database key file. Just a small change... :)

Thanks and cheers,
DeF-ault