### PR TITLE
App throws NPE during resume after sometime in background

### DIFF
--- a/KeePass/EntryDetails.xaml.cs
+++ b/KeePass/EntryDetails.xaml.cs
@@ -135,7 +135,7 @@ namespace KeePass
             }
 
             DateTime convertedDate;
-            if (Cache.DbInfo.Details.Modified != null)
+            if ((Cache.DbInfo != null) && (Cache.DbInfo.Details.Modified != null))
             {
                 convertedDate = DateTime.Parse(Cache.DbInfo.Details.Modified);
                 ApplicationTitle.Text = "8Pass - " + Cache.DbInfo.Details.Name + " (" + convertedDate + ")";

--- a/KeePass/GroupDetails.xaml.cs
+++ b/KeePass/GroupDetails.xaml.cs
@@ -66,7 +66,7 @@ namespace KeePass
             var database = Cache.Database;
 
             DateTime convertedDate;
-            if (Cache.DbInfo.Details.Modified != null)
+            if ((Cache.DbInfo != null) && (Cache.DbInfo.Details.Modified != null))
             {
                 convertedDate = DateTime.Parse(Cache.DbInfo.Details.Modified);
                 ApplicationTitle.Text = "8Pass - " + Cache.DbInfo.Details.Name + " (" + convertedDate + ")"; 


### PR DESCRIPTION
Hi bilbob74,

I found out today that the app will throw a NullPointerExecption Dialog, if it is resumed from background after about 5 mins (when user was on EntryDetails and GroupDetails). To avoid it, I added a null check on Cache.DBInfo field (Cache.DbInfo is null) in both views. The result is that no exception dialog appears and the app goes back to MainPage and you have to log into database again. It's a security feature for me... ;-)

May be this is also ok for you? :-)

Thanks and cheers,
DeF-ault